### PR TITLE
[Feat] 캘린더 API 연동 반영

### DIFF
--- a/src/components/school/home/TimeTable/SubjectBox.tsx
+++ b/src/components/school/home/TimeTable/SubjectBox.tsx
@@ -14,11 +14,11 @@ export default SubjectBox;
 
 const Container = styled.div`
   display: flex;
-  padding: 6px;
+  padding: 6px 10px;
   justify-content: center;
   align-items: center;
-  height: 30px;
-  white-space: nowrap;
+  height: 40px;
+  text-align: center;
 
   ${(props) => props.theme.fonts.caption1_m};
   color: ${({ theme }) => theme.colors.b400};

--- a/src/components/school/home/TimeTable/TimeBox.tsx
+++ b/src/components/school/home/TimeTable/TimeBox.tsx
@@ -20,7 +20,7 @@ export default TimeBox;
 const Container = styled.div`
   display: flex;
   width: 30px;
-  height: 30px;
+  height: 40px;
   justify-content: center;
   align-items: center;
   gap: 3px;
@@ -29,6 +29,7 @@ const Container = styled.div`
   background: ${({ theme }) => theme.colors.b200};
 
   &.zero {
+    height: 30px;
     background: ${({ theme }) => theme.colors.b100};
     color: ${({ theme }) => theme.colors.b100};
   }

--- a/src/components/school/home/TimeTable/TimeTableBox.tsx
+++ b/src/components/school/home/TimeTable/TimeTableBox.tsx
@@ -2,27 +2,40 @@ import TimeBox from "./TimeBox";
 import SubjectBox from "./SubjectBox";
 import styled, { css } from "styled-components";
 import getWeekTimetable from "@/apis/timetable/getWeekTimetable";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
+type DayOfWeek = "MONDAY" | "TUESDAY" | "WEDNESDAY" | "THURSDAY" | "FRIDAY";
 
 const TimeTableBox = () => {
   const TimeData = [1, 2, 3, 4, 5];
   const Week = ["월", "화", "수", "목", "금"];
   const todayIndex = new Date().getDay() - 1;
-  const [mondaySubject, setMondaySubject] = useState([]);
-  const [tuesdaySubject, setTuesdaySubject] = useState([]);
-  const [wednesdaySubject, setWednesdaySubject] = useState([]);
-  const [thursdaySubject, setThursdaySubject] = useState([]);
-  const [fridaySubject, setFridaySubject] = useState([]);
 
-  const getTimetableData = async () => {
-    const response = await getWeekTimetable();
-    setMondaySubject(response.timetables.MONDAY);
-    setTuesdaySubject(response.timetables.TUESDAY);
-    setWednesdaySubject(response.timetables.WEDNESDAY);
-    setThursdaySubject(response.timetables.THURSDAY);
-    setFridaySubject(response.timetables.FRIDAY);
+  const [subjects, setSubjects] = useState({
+    MONDAY: [],
+    TUESDAY: [],
+    WEDNESDAY: [],
+    THURSDAY: [],
+    FRIDAY: [],
+  });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const response = await getWeekTimetable();
+      setSubjects(response.timetables);
+    };
+    fetchData();
+  }, []);
+
+  const renderSubjectColumns = () => {
+    return (Object.keys(subjects) as DayOfWeek[]).map((day, index) => (
+      <SubjectCol highlight={index === todayIndex} key={day}>
+        {subjects[day].map(({ subject }, idx) => (
+          <SubjectBox subject={subject} key={idx} />
+        ))}
+      </SubjectCol>
+    ));
   };
-  getTimetableData();
 
   return (
     <Container>
@@ -42,33 +55,7 @@ const TimeTableBox = () => {
             <TimeBox time={time} key={index} />
           ))}
         </TimeListBox>
-        <SubjectListBox>
-          <SubjectCol highlight={todayIndex === 0}>
-            {mondaySubject.map(({ subject }, index) => (
-              <SubjectBox subject={subject} key={index} />
-            ))}
-          </SubjectCol>
-          <SubjectCol highlight={todayIndex === 1}>
-            {tuesdaySubject.map(({ subject }, index) => (
-              <SubjectBox subject={subject} key={index} />
-            ))}
-          </SubjectCol>
-          <SubjectCol highlight={todayIndex === 2}>
-            {wednesdaySubject.map(({ subject }, index) => (
-              <SubjectBox subject={subject} key={index} />
-            ))}
-          </SubjectCol>
-          <SubjectCol highlight={todayIndex === 3}>
-            {thursdaySubject.map(({ subject }, index) => (
-              <SubjectBox subject={subject} key={index} />
-            ))}
-          </SubjectCol>
-          <SubjectCol highlight={todayIndex === 4}>
-            {fridaySubject.map(({ subject }, index) => (
-              <SubjectBox subject={subject} key={index} />
-            ))}
-          </SubjectCol>
-        </SubjectListBox>
+        <SubjectListBox>{renderSubjectColumns()}</SubjectListBox>
       </TimetableBottom>
     </Container>
   );

--- a/src/components/school/home/TimeTable/TimeTableBox.tsx
+++ b/src/components/school/home/TimeTable/TimeTableBox.tsx
@@ -1,19 +1,28 @@
 import TimeBox from "./TimeBox";
 import SubjectBox from "./SubjectBox";
 import styled, { css } from "styled-components";
-
-const subjectsData = [
-  { id: 1, subject: ["영어", "수학", "체육", "사회", "국어"] },
-  { id: 2, subject: ["사회", "사회", "영어", "체육", "과학", "국어"] },
-  { id: 3, subject: ["도덕", "수학", "자율", "자율", "국어"] },
-  { id: 4, subject: ["음악", "미술", "미술", "수학", "과학"] },
-  { id: 5, subject: ["수학", "음악", "국어", "과학", "국어"] },
-];
+import getWeekTimetable from "@/apis/timetable/getWeekTimetable";
+import { useState } from "react";
 
 const TimeTableBox = () => {
   const TimeData = [1, 2, 3, 4, 5];
   const Week = ["월", "화", "수", "목", "금"];
   const todayIndex = new Date().getDay() - 1;
+  const [mondaySubject, setMondaySubject] = useState([]);
+  const [tuesdaySubject, setTuesdaySubject] = useState([]);
+  const [wednesdaySubject, setWednesdaySubject] = useState([]);
+  const [thursdaySubject, setThursdaySubject] = useState([]);
+  const [fridaySubject, setFridaySubject] = useState([]);
+
+  const getTimetableData = async () => {
+    const response = await getWeekTimetable();
+    setMondaySubject(response.timetables.MONDAY);
+    setTuesdaySubject(response.timetables.TUESDAY);
+    setWednesdaySubject(response.timetables.WEDNESDAY);
+    setThursdaySubject(response.timetables.THURSDAY);
+    setFridaySubject(response.timetables.FRIDAY);
+  };
+  getTimetableData();
 
   return (
     <Container>
@@ -34,13 +43,31 @@ const TimeTableBox = () => {
           ))}
         </TimeListBox>
         <SubjectListBox>
-          {subjectsData.map((data, index) => (
-            <SubjectCol key={index} highlight={index === todayIndex}>
-              {data.subject.map((subject, index) => (
-                <SubjectBox subject={subject} key={index} />
-              ))}
-            </SubjectCol>
-          ))}
+          <SubjectCol highlight={todayIndex === 0}>
+            {mondaySubject.map(({ subject }, index) => (
+              <SubjectBox subject={subject} key={index} />
+            ))}
+          </SubjectCol>
+          <SubjectCol highlight={todayIndex === 1}>
+            {tuesdaySubject.map(({ subject }, index) => (
+              <SubjectBox subject={subject} key={index} />
+            ))}
+          </SubjectCol>
+          <SubjectCol highlight={todayIndex === 2}>
+            {wednesdaySubject.map(({ subject }, index) => (
+              <SubjectBox subject={subject} key={index} />
+            ))}
+          </SubjectCol>
+          <SubjectCol highlight={todayIndex === 3}>
+            {thursdaySubject.map(({ subject }, index) => (
+              <SubjectBox subject={subject} key={index} />
+            ))}
+          </SubjectCol>
+          <SubjectCol highlight={todayIndex === 4}>
+            {fridaySubject.map(({ subject }, index) => (
+              <SubjectBox subject={subject} key={index} />
+            ))}
+          </SubjectCol>
         </SubjectListBox>
       </TimetableBottom>
     </Container>

--- a/src/interface/Timetable.ts
+++ b/src/interface/Timetable.ts
@@ -8,5 +8,5 @@ export interface Week {
 }
 
 export interface GetWeekTimetableResponse {
-  timetables: Week[];
+  timetables: Week[] | any;
 }


### PR DESCRIPTION
## 연관 이슈

- close #104

<br/>

## 📁 작업 내용

- 캘린더 API 연동 반영
- 캘린더 연동에 따른 디자인 높이 변경

<br/>

## 📁 구현 결과 (선택)

![image](https://github.com/Kusitms-29th-ASAP/Frontend/assets/97819580/4125771f-b39e-4461-bbfa-999cbc64d324)

<br/>

## 📁 기타 사항

슬기로운 생활, 바른생활, 자율 자치활동 등등 다르게 두 줄이 되는 게 마음에 들지 않아요!!!
padding을 통해서 해결해보려구 하는데, 마음에 드는 크기를 찾지 못했어요.

<br/>
