### PR TITLE
[Design] 마이페이지 설정 UI 및 폰트 변경 기능

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -3,8 +3,12 @@
 import deleteUser from "@/apis/auth/deleteUser";
 import Axios from "@/apis/axios";
 import getUserInfo from "@/apis/user/getUserInfo";
+import Checkbox from "@/components/common/Checkbox";
+import CustomInput from "@/components/common/CustomInput";
 import Tabbar from "@/components/common/Tabbar";
 import Topbar from "@/components/common/Topbar";
+import { FONT_SIZE } from "@/constants/font";
+import { LANGUAGE } from "@/constants/language";
 import { RootState } from "@/redux/store";
 import { theme } from "@/styles/theme";
 import Image from "next/image";
@@ -43,6 +47,10 @@ const Mypage = () => {
   const [userName, setUserName] = useState("");
   const [phoneNumber, setPhoneNumber] = useState("");
 
+  const [language, setLanguage] = useState<string>("");
+  const [fontSize, setFontSize] = useState<number>(FONT_SIZE[0].id);
+  const [openDropdown, setOpenDropdown] = useState(false);
+
   const userInfo = async () => {
     const data = await getUserInfo();
     setUserName(data.userName);
@@ -55,6 +63,29 @@ const Mypage = () => {
   }
   const newPhoneNumber = formatPhoneNumber(phoneNumber);
 
+  const handleTypeSelectClick = () => {
+    setOpenDropdown(!openDropdown);
+  };
+
+  const handleSelectDrop = (selectedDrop: string) => {
+    setLanguage(selectedDrop);
+    setOpenDropdown(false);
+
+    const selectedLanguage = LANGUAGE.find(
+      (lang) => lang.text === selectedDrop
+    );
+
+    if (selectedLanguage) {
+      localStorage.setItem("language", selectedLanguage.eng);
+    }
+  };
+
+  const handleCheckboxChange = (item: { id: number }) => {
+    setFontSize(item.id);
+
+    localStorage.setItem("fontSize", item.id.toString());
+  };
+
   const handleLogout = () => {
     deleteUser(refreshToken);
     router.push("/");
@@ -65,23 +96,43 @@ const Mypage = () => {
   useEffect(() => {
     if (childList.length > 0) {
       const primaryChild = childList.find((child) => child.isPrimary);
-      Axios.get(`/api/v1/children/${primaryChild?.childId}`)
-        .then((response) => {
+      Axios.get(`/api/v1/children/${primaryChild?.childId}`).then(
+        (response) => {
           const data = response.data;
           setChild(data);
-        })
-        .catch((error) => {});
+        }
+      );
     }
   }, [childList]);
 
   /* 자녀 전체 불러오기 */
   useEffect(() => {
-    Axios.get(`/api/v1/children`)
-      .then((response) => {
-        const data = response.data.childList;
-        setChildList(data);
-      })
-      .catch((error) => {});
+    Axios.get(`/api/v1/children`).then((response) => {
+      const data = response.data.childList;
+      setChildList(data);
+    });
+  }, []);
+
+  /* 언어 및 폰트 정보 불러오기 */
+  useEffect(() => {
+    const storedLanguageEng = localStorage.getItem("language");
+    if (storedLanguageEng) {
+      const matchingLanguage = LANGUAGE.find(
+        (lang) => lang.eng === storedLanguageEng
+      );
+      if (matchingLanguage) {
+        setLanguage(matchingLanguage.text);
+      }
+    } else {
+      localStorage.setItem("language", "한국어");
+    }
+
+    const storedFontSize = localStorage.getItem("fontSize");
+    if (storedFontSize) {
+      setFontSize(parseInt(storedFontSize));
+    } else {
+      localStorage.setItem("fontSize", 0 + "");
+    }
   }, []);
 
   return (
@@ -148,6 +199,49 @@ const Mypage = () => {
           </Line>
         </ColContainCard>
         <ColContainCard>
+          <Title>환경설정</Title>
+          <div>
+            <Label>언어</Label>
+            <Box>
+              <StyledInput
+                value={language}
+                onClick={handleTypeSelectClick}
+                onChange={() => {}}
+                placeholder="언어"
+                inputType="select"
+                clicked={openDropdown}
+              />
+              {openDropdown && (
+                <DropDown>
+                  {LANGUAGE.map((data) => (
+                    <Cusor
+                      key={data.id}
+                      onClick={() => handleSelectDrop(data.text)}
+                    >
+                      {data.text}
+                    </Cusor>
+                  ))}
+                </DropDown>
+              )}
+            </Box>
+          </div>
+          <div>
+            <Label>글자 크기</Label>
+            <CheckboxBox>
+              {FONT_SIZE.map((item) => (
+                <Checkbox
+                  key={item.id}
+                  label={item.label}
+                  checkboxType="checkBtn"
+                  checked={fontSize === item.id}
+                  onChange={() => handleCheckboxChange(item)}
+                  justifyContent="space-between"
+                />
+              ))}
+            </CheckboxBox>
+          </div>
+        </ColContainCard>
+        <ColContainCard>
           <LogOut onClick={handleLogout}>로그아웃</LogOut>
           <DeleteUser onClick={handleDeleteUser}>회원탈퇴</DeleteUser>
         </ColContainCard>
@@ -174,10 +268,11 @@ const Padding = styled.div`
 
 const Background = styled.div`
   height: 100%;
+  min-height: 820px;
   display: flex;
   flex-direction: column;
   gap: 20px;
-  padding: 20px 20px;
+  padding: 20px;
   background: ${theme.colors.b80};
 `;
 
@@ -252,6 +347,62 @@ const DarkGray = styled.div`
 
 const DarkGrayCap = styled(DarkGray)`
   ${(props) => props.theme.fonts.caption1_r};
+`;
+
+const Title = styled.div`
+  color: ${theme.colors.b700};
+  ${(props) => props.theme.fonts.body1_b};
+`;
+
+const Label = styled.div`
+  color: ${theme.colors.b700};
+  ${(props) => props.theme.fonts.body3_b};
+  margin-bottom: 5px;
+`;
+
+const Box = styled.div`
+  position: relative;
+`;
+
+const StyledInput = styled(CustomInput)`
+  position: absolute;
+  top: 0;
+  left: 0;
+`;
+
+const DropDown = styled.div`
+  width: 100%;
+  position: absolute;
+  top: 44px;
+  left: 0;
+  padding: 16px 218px 16px 16px;
+  border-radius: 10px;
+  border: 1px solid ${theme.colors.b200};
+  background: ${theme.colors.white};
+  box-shadow: 0px 2px 64px 0px rgba(30, 41, 59, 0.06);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  color: ${theme.colors.b500};
+  ${(props) => props.theme.fonts.body3_b};
+`;
+
+const CheckboxBox = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(120px, 1fr));
+  gap: 8px;
+
+  @media screen and (max-width: 330px) {
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(2, 1fr);
+  }
+`;
+
+const Cusor = styled.div`
+  white-space: nowrap;
+  cursor: pointer;
 `;
 
 const LogOut = styled.div`

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -48,7 +48,7 @@ const Mypage = () => {
   const [phoneNumber, setPhoneNumber] = useState("");
 
   const [language, setLanguage] = useState<string>("");
-  const [fontSize, setFontSize] = useState<number>(FONT_SIZE[0].id);
+  const [fontSize, setFontSize] = useState<number>(1);
   const [openDropdown, setOpenDropdown] = useState(false);
 
   const userInfo = async () => {
@@ -80,10 +80,11 @@ const Mypage = () => {
     }
   };
 
-  const handleCheckboxChange = (item: { id: number }) => {
-    setFontSize(item.id);
+  const handleCheckboxChange = (item: { size: number }) => {
+    setFontSize(item.size);
+    localStorage.setItem("fontSize", item.size.toString());
 
-    localStorage.setItem("fontSize", item.id.toString());
+    window.location.reload();
   };
 
   const handleLogout = () => {
@@ -129,7 +130,7 @@ const Mypage = () => {
 
     const storedFontSize = localStorage.getItem("fontSize");
     if (storedFontSize) {
-      setFontSize(parseInt(storedFontSize));
+      setFontSize(parseFloat(storedFontSize));
     } else {
       localStorage.setItem("fontSize", 0 + "");
     }
@@ -233,7 +234,7 @@ const Mypage = () => {
                   key={item.id}
                   label={item.label}
                   checkboxType="checkBtn"
-                  checked={fontSize === item.id}
+                  checked={fontSize === item.size}
                   onChange={() => handleCheckboxChange(item)}
                   justifyContent="space-between"
                 />

--- a/src/components/common/Checkbox.tsx
+++ b/src/components/common/Checkbox.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 
 type checkboxType = "checkbox" | "grayCheckbox" | "checkBtn" | "checkArrow";
 type checkboxColor = "primary" | "gray" | "black";
+type justifyContentType = "" | "space-between";
 
 export interface CheckBoxProps {
   checkboxType?: checkboxType;
@@ -14,6 +15,7 @@ export interface CheckBoxProps {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   essential?: boolean;
   color?: checkboxColor;
+  justifyContent?: justifyContentType;
 }
 
 const Checkbox = (props: CheckBoxProps) => {
@@ -26,6 +28,7 @@ const Checkbox = (props: CheckBoxProps) => {
     onChange,
     essential,
     color = "gray",
+    justifyContent = "",
   } = props;
 
   let checkboxClassName = checkboxType;
@@ -38,6 +41,7 @@ const Checkbox = (props: CheckBoxProps) => {
       <CheckboxContainer
         essential={essential ? true : false}
         checked={checked || false}
+        justifyContent={justifyContent}
       >
         <CheckboxInput
           className={checkboxClassName}
@@ -47,7 +51,7 @@ const Checkbox = (props: CheckBoxProps) => {
           onChange={onChange}
         />
         {label}
-        <span className={checkboxClassName}>{text}</span>
+        {text && <span className={checkboxClassName}>{text}</span>}
       </CheckboxContainer>
       {checkboxType === "checkArrow" && (
         <Image
@@ -108,9 +112,11 @@ const CheckBoxLayout = styled.div<{ $check: boolean }>`
 const CheckboxContainer = styled.label<{
   essential: boolean;
   checked: boolean;
+  justifyContent: string;
 }>`
   display: flex;
   align-items: center;
+  justify-content: ${({ justifyContent }) => justifyContent && justifyContent};
   flex-grow: 1;
   cursor: pointer;
 

--- a/src/components/common/CustomInput.tsx
+++ b/src/components/common/CustomInput.tsx
@@ -101,7 +101,6 @@ const StyledInput = styled.input<CustomInputProps>`
     props.hidden ? "rgba(255, 135, 0, 0.01)" : theme.colors.b700};
   ${(props) => props.theme.fonts.body3_m};
   outline: none;
-  ${(props) => props.theme.fonts.caption1_m};
 
   &::placeholder {
     color: ${theme.colors.b400};

--- a/src/constants/font.ts
+++ b/src/constants/font.ts
@@ -1,0 +1,12 @@
+export const FONT_SIZE = [
+    {
+        id: 0,
+        label: "기본",
+        size: 1,
+    },
+    {
+        id: 1,
+        label: "1.2배",
+        size: 1.2,
+    },
+];

--- a/src/constants/language.ts
+++ b/src/constants/language.ts
@@ -1,0 +1,31 @@
+export const LANGUAGE = [{
+    id: 0,
+    kor:"한국어",
+    eng: "ko",
+    text: "한국어"
+},{
+    id: 1,
+    kor:"영어",
+    eng: "en",
+    text: "English"
+},{
+    id: 2,
+    kor:"중국어",
+    eng: "zh",
+    text: "中文"
+},{
+    id: 3,
+    kor:"일본어",
+    eng: "ja",
+    text: "日本語"
+},{
+    id: 4,
+    kor:"베트남어",
+    eng: "vi",
+    text: "tiếng Việt"
+},{
+    id: 5,
+    kor:"타갈로그어",
+    eng: "pi",
+    text: "Tagalog"
+}]

--- a/src/data/mypageData.ts
+++ b/src/data/mypageData.ts
@@ -44,39 +44,3 @@ export const docsData: Docs[] = [
     guardian: "유진주",
   },
 ];
-
-export interface ChildrenList {
-  name: string;
-  school: string;
-  grade: number;
-  class: number;
-  birth: string;
-  allergy: string[];
-}
-
-export const childrenListData: ChildrenList[] = [
-  {
-    name: "김동우",
-    school: "양원숲초등학교",
-    grade: 3,
-    class: 7,
-    birth: "2014년 4월 5일",
-    allergy: ["난류"],
-  },
-  {
-    name: "김규리",
-    school: "양원숲초등학교",
-    grade: 1,
-    class: 7,
-    birth: "2014년 4월 1일",
-    allergy: ["우유"],
-  },
-  {
-    name: "오민지",
-    school: "강남초등학교",
-    grade: 6,
-    class: 5,
-    birth: "2014년 3월 1일",
-    allergy: ["닭고기", "우유"],
-  },
-];

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -35,11 +35,17 @@ interface Font {
   size: number;
 }
 
+const getFontSizeMultiplier = (): number => {
+    const storedFontSize = localStorage.getItem("fontSize");
+    return storedFontSize ? parseFloat(storedFontSize) : 1;
+};
+
 const FONT = ({ weight, size }: Font): string => {
+  const fontSizeMultiplier = getFontSizeMultiplier();
   return `
     font-family : "Pretendard";
     font-weight : ${weight};
-    font-size : ${size}px; 
+    font-size : ${size *fontSizeMultiplier}px; 
     line-height : ${size * 1.5}px;
     `;
 };


### PR DESCRIPTION
## 연관 이슈

close #132

<br/>

## 📁 작업 내용
마이페이지 폰트, 언어 설정

- 폰트 사이즈 체크박스
- 언어 드롭다운
- 폰트, 언어 localStorage 저장
- 폰트 변경 기능

<br/>

## 📁 구현 결과 (선택)

https://github.com/user-attachments/assets/cde9770c-7b58-4550-aa31-8135760f15ca



<br/>

## 📁 기타 사항
- 폰트 변경 기능도 한번에 할 수 있을 것 같아서 그냥 작업했어요!
- 폰트 사이즈랑 언어 둘다 백엔드에서 안 받아오는데 유저별로 설정되어야 하니까 로컬 스토리지로 관리는 필수일 거 같아요. 로컬 스토리지에 language로 저장되는 거는 백엔드에 호출할 때 쓰는 값의 형태로 넣어놨고 자세한 건 ```/constant/language.ts``` 보면 됩니다!
- 폰트 사이즈 변경에서 이슈가 있는데, redux나 contextAPI 써서 theme에서 useSelector 혹은 useFont 라는 제가 정의한 훅을 사용해 적용하려 했는데 똑같은 오류가 계속 뜨더라구요.. 그래서 적용 못하구 그냥 로컬스토리지에서 받아서 체크박스값 변경될 때마다 새로고침 시켜서 적용하도록 했어요.
(궁금한 점 - 로컬 스토리지가 있는데 리덕스를 쓰는게 좋은건지?는 잘 모르겠어요.)
새로고침 안하면 체크박스 클릭시에 바로바로 폰트 사이즈가 바뀌진 않더라구요...

- 뒤에 작업하면서 한번 보구 개선할 부분 보이면 언제든 변경해주세요! 만약에 지금대로 가면 새로고침 시에 보일 loading 화면 필요할 것 같아요
<br/>
