### PR TITLE
[Feat] 한국어, 영어, 중국어, 일본어, 베트남어, 필리핀어 언어 번역

### DIFF
--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -7,11 +7,19 @@ const getToken = () => {
   return null;
 };
 
+const getLanguage = () => {
+  if (typeof window !== "undefined") {
+    return localStorage.getItem("language");
+  }
+  return null;
+};
+
 const Axios = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
   headers: {
     Authorization: `Bearer ${getToken()}`,
     "Content-Type": "application/json;charset=UTF-8",
+    "Accept-Language": `${getLanguage()}`,
   },
 });
 export default Axios;

--- a/src/app/school/homeGuide/reply/page.tsx
+++ b/src/app/school/homeGuide/reply/page.tsx
@@ -4,16 +4,26 @@ import Button from "@/components/common/Button";
 import Topbar from "@/components/common/Topbar";
 import styled from "styled-components";
 import Image from "next/image";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Toast from "@/components/common/Toast";
 import FormPopup from "@/components/school/homeGuide/FormPopup";
+import { ToastMessages } from "@/data/toastMessagesData";
 
 const HomeGuideForm = () => {
   const [writeForm, setWriteForm] = useState(false);
   const [showToast, setShowToast] = useState(false);
+  const [language, setLanguage] = useState<string>("ko");
+
+  useEffect(() => {
+    const lang = localStorage.getItem("language") || "ko";
+    setLanguage(lang);
+  }, []);
+
   const handleWriteFormClick = () => {
     setWriteForm(!writeForm);
   };
+
+  const message = ToastMessages[language as keyof typeof ToastMessages];
 
   return (
     <Container>
@@ -37,7 +47,7 @@ const HomeGuideForm = () => {
       )}
       {showToast && (
         <Toast
-          message="제출이 완료되었어요!"
+          message={message}
           type="basic"
           duration={3000}
           onClose={() => setShowToast(false)}

--- a/src/components/common/ListBox.tsx
+++ b/src/components/common/ListBox.tsx
@@ -25,6 +25,7 @@ export interface ListBoxProps {
   onClick?: () => void;
   onDelete?: () => void;
 }
+
 const ListBox = (props: ListBoxProps) => {
   const {
     id,
@@ -45,27 +46,47 @@ const ListBox = (props: ListBoxProps) => {
   } = props;
 
   const [futureDate, setFutureDate] = useState("");
-  const [futureWeekday, setFutureWeekday] = useState("");
+  const [language, setLanguage] = useState<string | null>("ko");
+
+  useEffect(() => {
+    setLanguage(localStorage.getItem("language") || "ko");
+  }, []);
 
   useEffect(() => {
     const now = new Date();
     const future = new Date(now.setDate(now.getDate() + dday));
-    const futureDateString = future.toLocaleDateString("ko-KR", {
-      weekday: "long",
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-    setFutureDate(futureDateString);
-    setFutureWeekday(
-      future
-        .toLocaleDateString("ko-KR", { weekday: "short" })
-        .replace("요일", "")
-    );
-  }, [dday]);
 
-  const month = futureDate.split(" ")[1];
-  const day = futureDate.split(" ")[2];
+    const formatDateString = (date: Date) => {
+      const options: Intl.DateTimeFormatOptions = {
+        month: "short",
+        day: "numeric",
+      };
+
+      let formattedDate = date.toLocaleDateString(language, options);
+
+      switch (language) {
+        case "ko":
+          return `${formattedDate} (${future.toLocaleDateString(language, {
+            weekday: "short",
+          })}) 까지`;
+        case "en":
+          return `By ${formattedDate}`;
+        case "zh":
+          return `${formattedDate}`;
+        case "ja":
+          return `${formattedDate}`;
+        case "vi":
+          return `Trước ${formattedDate}`;
+        case "pi":
+          const day = date.getDate();
+          return `Hanggang ${day} Ago`;
+        default:
+          return `${formattedDate} 까지`;
+      }
+    };
+
+    setFutureDate(formatDateString(future));
+  }, [dday, language]);
 
   let listboxClassName = listboxType;
   if (color === "orange") {
@@ -99,7 +120,7 @@ const ListBox = (props: ListBoxProps) => {
                 </span>
               )}
               <span style={{ fontSize: "12px", fontWeight: "500" }}>
-                {month} {day} ({futureWeekday}) 까지
+                {futureDate}
               </span>
             </>
           )}

--- a/src/components/common/ListBox.tsx
+++ b/src/components/common/ListBox.tsx
@@ -46,7 +46,7 @@ const ListBox = (props: ListBoxProps) => {
   } = props;
 
   const [futureDate, setFutureDate] = useState("");
-  const [language, setLanguage] = useState<string | null>("ko");
+  const [language, setLanguage] = useState<string>("ko");
 
   useEffect(() => {
     setLanguage(localStorage.getItem("language") || "ko");

--- a/src/components/school/home/HomeGuideRemind.tsx
+++ b/src/components/school/home/HomeGuideRemind.tsx
@@ -3,12 +3,84 @@ import WhiteBox from "../WhiteBox";
 import More from "@/components/common/More";
 import ListBox from "@/components/common/ListBox";
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+const textContent = {
+  ko: {
+    listBox1: {
+      text: "현장체험학습 실시 찬반의견 조사",
+      time: "회신 필요",
+    },
+    listBox2: {
+      text: "양원숲 토닥토닥 상담실 운영 안내 및 보호자 동의 안내",
+      time: "제출 완료",
+    },
+  },
+  en: {
+    listBox1: {
+      text: "Field Trip Participation Survey",
+      time: "Reply-needed",
+    },
+    listBox2: {
+      text: "After-School Program Form",
+      time: "Submitted",
+    },
+  },
+  zh: {
+    listBox1: {
+      text: "郊游参与调查",
+      time: "需回复",
+    },
+    listBox2: {
+      text: "课后活动申请表",
+      time: "提交完成",
+    },
+  },
+  ja: {
+    listBox1: {
+      text: "遠足参加調査",
+      time: "回答必要",
+    },
+    listBox2: {
+      text: "放課後プログラム申込書",
+      time: "提出済み",
+    },
+  },
+  vi: {
+    listBox1: {
+      text: "Khảo sát tham gia dã ngoại",
+      time: "Cần-hồi đáp",
+    },
+    listBox2: {
+      text: "Đăng ký ngoại khóa",
+      time: "Đã nộp",
+    },
+  },
+  pi: {
+    listBox1: {
+      text: "Suri sa paglahok sa picnic",
+      time: "Walang-tugon",
+    },
+    listBox2: {
+      text: "Form para sa after-school",
+      time: "Nai-submit na",
+    },
+  },
+};
 
 const HomeGuideRemind = () => {
   const router = useRouter();
   const handleDetailClick = () => {
     router.push("/school/homeGuide");
   };
+  const [language, setLanguage] = useState<string | null>("ko");
+
+  useEffect(() => {
+    setLanguage(localStorage.getItem("language") || "ko");
+  }, []);
+
+  const currentText =
+    textContent[language as keyof typeof textContent] || textContent.ko;
 
   return (
     <WhiteBox>
@@ -20,14 +92,14 @@ const HomeGuideRemind = () => {
       </TitleBox>
       <ListBox
         color="orange"
-        text="현장체험학습 실시 찬반의견 조사"
-        time="회신 필요"
+        text={currentText.listBox1.text}
+        time={currentText.listBox1.time}
         dday={2}
       />
       <ListBox
         color="mint"
-        text="양원숲 토닥토닥 상담실 운영 안내 및 보호자 동의 안내"
-        time="제출 완료"
+        text={currentText.listBox2.text}
+        time={currentText.listBox2.time}
         dday={-2}
       />
     </WhiteBox>

--- a/src/components/school/homeGuide/FormPopup.tsx
+++ b/src/components/school/homeGuide/FormPopup.tsx
@@ -1,8 +1,9 @@
 import styled from "styled-components";
-import { Dispatch, useState } from "react";
+import { Dispatch, useState, useEffect } from "react";
 import Popup from "@/components/common/Popup";
 import Button from "@/components/common/Button";
 import Checkbox from "@/components/common/Checkbox";
+import { HomeGuideFormPopup } from "@/data/homeGuideData";
 
 interface FormPopupProps {
   onClose: () => void;
@@ -11,9 +12,16 @@ interface FormPopupProps {
 
 const FormPopup = (props: FormPopupProps) => {
   const [selectedOption, setSelectedOption] = useState<number | null>(null);
+  const [language, setLanguage] = useState<string>("ko");
+
   const { onClose, setShowToast } = props;
 
-  const Title = `3학년 현장체험학습 실시 여부에 \n동의하시겠습니까?`;
+  useEffect(() => {
+    const lang = localStorage.getItem("language") || "ko";
+    setLanguage(lang);
+  }, []);
+
+  const data = HomeGuideFormPopup[language as keyof typeof HomeGuideFormPopup];
 
   const isButtonEnabled = selectedOption !== null;
 
@@ -21,31 +29,32 @@ const FormPopup = (props: FormPopupProps) => {
     onClose();
     setShowToast && setShowToast(true);
   };
+
   const handleCheckboxChange = (option: number) => {
     setSelectedOption(option);
   };
 
   return (
     <>
-      <Popup onClose={onClose} title={Title} height="394px">
+      <Popup onClose={onClose} title={data.title} height="394px">
         <ContentBox>
           <CheckBoxContainer>
             <Checkbox
               checkboxType="checkBtn"
-              label="동의함"
+              label={data.agree}
               checked={selectedOption === 0}
               onChange={() => handleCheckboxChange(0)}
             />
             <Checkbox
               checkboxType="checkBtn"
-              label="동의하지 않음"
+              label={data.disagree}
               checked={selectedOption === 1}
               onChange={() => handleCheckboxChange(1)}
             />
           </CheckBoxContainer>
 
           <Button
-            text="제출하기"
+            text={data.submit}
             onClick={handleButtonClick}
             disabled={!isButtonEnabled}
           />

--- a/src/components/school/homeGuide/ReplyCompleted.tsx
+++ b/src/components/school/homeGuide/ReplyCompleted.tsx
@@ -1,11 +1,32 @@
 import CustomInput from "@/components/common/CustomInput";
 import ListBox from "@/components/common/ListBox";
-import { HomeGideReplyCompletedData } from "@/data/notifyData";
-import { useState } from "react";
+import { HomeGuideReplyCompletedData } from "@/data/notifyData";
+import { useState, useEffect } from "react";
 import styled from "styled-components";
 
+const weekTranslations = {
+  ko: "지난주",
+  en: "Last week",
+  zh: "上周",
+  ja: "先週",
+  vi: "Tuần trước",
+};
+
 const ReplyCompleted = () => {
-  const [selected, setSelected] = useState<string>("지난주");
+  const [language, setLanguage] = useState<"ko" | "en" | "zh" | "ja" | "vi">(
+    "ko"
+  );
+  const selected = weekTranslations[language];
+
+  useEffect(() => {
+    const lang = localStorage.getItem("language") as
+      | "ko"
+      | "en"
+      | "zh"
+      | "ja"
+      | "vi";
+    setLanguage(lang);
+  }, []);
 
   return (
     <>
@@ -17,13 +38,13 @@ const ReplyCompleted = () => {
         <CustomInput inputType="select" value={selected} onChange={() => {}} />
       </Container>
       <Background>
-        {HomeGideReplyCompletedData.map((data) => (
+        {HomeGuideReplyCompletedData.map((data) => (
           <ListBox
             key={data.id}
-            time={"제출 완료"}
+            time={data.content[language].time}
             listboxType={"content"}
-            content1={data.content1}
-            content2={data.content2}
+            content1={data.content[language].content1}
+            content2={data.content[language].content2}
             color={"mint"}
           />
         ))}

--- a/src/components/school/homeGuide/ReplyRequired.tsx
+++ b/src/components/school/homeGuide/ReplyRequired.tsx
@@ -1,12 +1,25 @@
 import ListBox from "@/components/common/ListBox";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
+import { useEffect, useState } from "react";
+import { HomeGuideReplyRequiredData } from "@/data/notifyData";
 
 const ReplyRequired = () => {
   const router = useRouter();
+  const [language, setLanguage] = useState<string | null>("ko");
+
+  useEffect(() => {
+    setLanguage(localStorage.getItem("language") || "ko");
+  }, []);
+
   const handleHomeGuideClick = () => {
     router.push("/school/homeGuide/reply");
   };
+
+  const currentText =
+    HomeGuideReplyRequiredData[0][
+      language as keyof (typeof HomeGuideReplyRequiredData)[0]
+    ] || HomeGuideReplyRequiredData[0].ko;
 
   return (
     <Container>
@@ -18,15 +31,15 @@ const ReplyRequired = () => {
       </TitleBox>
       <ListBoxContainer>
         <ListBox
-          text={"현장체험학습 실시 찬반의견 조사"}
-          time={"회신 필요"}
+          text={currentText.listBox1.text}
+          time={currentText.listBox1.time}
           dday={2}
           color={"orange"}
           onClick={handleHomeGuideClick}
         />
         <ListBox
-          text={"방과후학교 프로그램 신청서"}
-          time={"제출 완료"}
+          text={currentText.listBox2.text}
+          time={currentText.listBox2.time}
           dday={5}
           color={"mint"}
           onClick={handleHomeGuideClick}

--- a/src/data/homeGuideData.ts
+++ b/src/data/homeGuideData.ts
@@ -1,0 +1,38 @@
+export const HomeGuideFormPopup = {
+  ko: {
+    title: "3학년 현장체험학습 실시 여부에 \n동의하시겠습니까?",
+    agree: "동의함",
+    disagree: "동의하지 않음",
+    submit: "제출하기",
+  },
+  en: {
+    title: "Do you agree with-the 3rd graders' field trip?",
+    agree: "Yes",
+    disagree: "No",
+    submit: "Submit",
+  },
+  zh: {
+    title: "您同意三年级学生郊游吗？",
+    agree: "同意",
+    disagree: "不同意",
+    submit: "提交",
+  },
+  ja: {
+    title: "3年生の遠足に同意しますか？",
+    agree: "同意",
+    disagree: "不同意",
+    submit: "提出",
+  },
+  vi: {
+    title: "Đồng ý cho lớp 3 đi dã ngoại?",
+    agree: "Đồng ý",
+    disagree: "Không đồng ý",
+    submit: "Nộp",
+  },
+  pi: {
+    title: "Pumapayag ka ba sa field trip-ng Grade 3?",
+    agree: "Oo",
+    disagree: "Hindi",
+    submit: "I-submit",
+  },
+};

--- a/src/data/notifyData.ts
+++ b/src/data/notifyData.ts
@@ -28,25 +28,210 @@ export const notiCardData = [
   },
 ];
 
-export const HomeGideReplyCompletedData = [
+export const HomeGuideReplyRequiredData = [
+  {
+    ko: {
+      listBox1: {
+        text: "현장체험학습 실시 찬반의견 조사",
+        time: "회신 필요",
+      },
+      listBox2: {
+        text: "방과후학교 프로그램 신청서",
+        time: "제출 완료",
+      },
+    },
+    en: {
+      listBox1: {
+        text: "Field Trip Participation Survey",
+        time: "Reply-needed",
+      },
+      listBox2: {
+        text: "After-School Program Form",
+        time: "Submitted",
+      },
+    },
+    zh: {
+      listBox1: {
+        text: "郊游参与调查",
+        time: "需回复",
+      },
+      listBox2: {
+        text: "课后活动申请表",
+        time: "提交完成",
+      },
+    },
+    ja: {
+      listBox1: {
+        text: "遠足参加調査",
+        time: "回答必要",
+      },
+      listBox2: {
+        text: "放課後プログラム申込書",
+        time: "提出済み",
+      },
+    },
+    vi: {
+      listBox1: {
+        text: "Khảo sát tham gia dã ngoại",
+        time: "Cần-hồi đáp",
+      },
+      listBox2: {
+        text: "Đăng ký ngoại khóa",
+        time: "Đã nộp",
+      },
+    },
+    pi: {
+      listBox1: {
+        text: "Suri sa paglahok sa picnic",
+        time: "Walang-tugon",
+      },
+      listBox2: {
+        text: "Form para sa after-school",
+        time: "Nai-submit na",
+      },
+    },
+  },
+];
+
+export const HomeGuideReplyCompletedData = [
   {
     id: 1,
-    content1: "2024 서울진로직업박람회 공모전",
-    content2: "교내외 프로그램",
+    content: {
+      ko: {
+        content1: "2024 서울진로직업박람회 공모전",
+        content2: "교내외 프로그램",
+        time: "제출 완료",
+      },
+      en: {
+        content1: "Job Fair Contest",
+        content2: "Student Program",
+        time: "Submitted",
+      },
+      zh: {
+        content1: "职业博览会竞赛",
+        content2: "学生项目",
+        time: "提交完成",
+      },
+      ja: {
+        content1: "職業フェアコンテスト",
+        content2: "学生向けプログラム",
+        time: "提出済み",
+      },
+      vi: {
+        content1: "Cuộc thi hội chợ việc làm",
+        content2: "Chương trình học sinh",
+        time: "Đã nộp",
+      },
+      pi: {
+        content1: "Kumpetisyon sa job fair",
+        content2: "Programa para estudyante",
+        time: "Nai-submit na",
+      },
+    },
   },
   {
     id: 2,
-    content1: "양원숲 토닥토닥 상담실 운영 안내",
-    content2: "교내외 프로그램",
+    content: {
+      ko: {
+        content1: "양원숲 토닥토닥 상담실 운영 안내",
+        content2: "교내외 프로그램",
+        time: "제출 완료",
+      },
+      en: {
+        content1: "Consulting Room Info",
+        content2: "School and External Programs",
+        time: "Submitted",
+      },
+      zh: {
+        content1: "咨询室运营",
+        content2: "学生项目",
+        time: "提交完成",
+      },
+      ja: {
+        content1: "相談室運営",
+        content2: "学生向けプログラム",
+        time: "提出済み",
+      },
+      vi: {
+        content1: "Hướng dẫn phòng tư vấn",
+        content2: "Chương trình học sinh",
+        time: "Đã nộp",
+      },
+      pi: {
+        content1: "Talaan ng konsultasyon",
+        content2: "Programa para estudyante",
+        time: "Nai-submit na",
+      },
+    },
   },
   {
     id: 3,
-    content1: "씨앗부터 시작하는 생생레시피",
-    content2: "교내외 프로그램",
+    content: {
+      ko: {
+        content1: "씨앗부터 시작하는 생생레시피",
+        content2: "교내외 프로그램",
+        time: "제출 완료",
+      },
+      en: {
+        content1: "Eco Transformation Program",
+        content2: "School and External Programs",
+        time: "Submitted",
+      },
+      zh: {
+        content1: "生态转型项目",
+        content2: "学生项目",
+        time: "提交完成",
+      },
+      ja: {
+        content1: "エコ転換プログラム",
+        content2: "学生向けプログラム",
+        time: "提出済み",
+      },
+      vi: {
+        content1: "Chuyển đổi sinh thái",
+        content2: "Chương trình học sinh",
+        time: "Đã nộp",
+      },
+      pi: {
+        content1: "Programa sa ekolohiya",
+        content2: "Programa para estudyante",
+        time: "Nai-submit na",
+      },
+    },
   },
   {
     id: 4,
-    content1: "영재교육원 3~4월 모집 요강 안내",
-    content2: "교내외 프로그램",
+    content: {
+      ko: {
+        content1: "영재교육원 3~4월 모집 요강 안내",
+        content2: "교내외 프로그램",
+        time: "제출 완료",
+      },
+      en: {
+        content1: "Gifted Enrollment",
+        content2: "School and External Programs",
+        time: "Submitted",
+      },
+      zh: {
+        content1: "才俊招生",
+        content2: "学生项目",
+        time: "提交完成",
+      },
+      ja: {
+        content1: "才能教育生募集",
+        content2: "学生向けプログラム",
+        time: "提出済み",
+      },
+      vi: {
+        content1: "Tuyển sinh tài năng",
+        content2: "Chương trình học sinh",
+        time: "Đã nộp",
+      },
+      pi: {
+        content1: "Pagkuha ng mga gifted",
+        content2: "Programa para estudyante",
+        time: "Nai-submit na",
+      },
+    },
   },
 ];

--- a/src/data/toastMessagesData.ts
+++ b/src/data/toastMessagesData.ts
@@ -1,0 +1,8 @@
+export const ToastMessages = {
+  ko: "제출이 완료되었어요!",
+  en: "Submitted",
+  zh: "提交完成",
+  ja: "提出済み",
+  vi: "Đã nộp",
+  pi: "Nai-submit na",
+};

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -36,8 +36,11 @@ interface Font {
 }
 
 const getFontSizeMultiplier = (): number => {
+  if (typeof window !== "undefined") {
     const storedFontSize = localStorage.getItem("fontSize");
     return storedFontSize ? parseFloat(storedFontSize) : 1;
+  }
+  return 1;
 };
 
 const FONT = ({ weight, size }: Font): string => {
@@ -45,7 +48,7 @@ const FONT = ({ weight, size }: Font): string => {
   return `
     font-family : "Pretendard";
     font-weight : ${weight};
-    font-size : ${size *fontSizeMultiplier}px; 
+    font-size : ${size * fontSizeMultiplier}px; 
     line-height : ${size * 1.5}px;
     `;
 };


### PR DESCRIPTION
## 연관 이슈

- close #135

<br/>

## 📁 작업 내용
 
한글 : ko
영어: en
중어: zh
일어: ja
베트남어: vi
필리핀어: pi

API 요청시 Header에 언어 추가
localStorage를 통해서 언어 선택 가능

```
const getLanguage = () => {
  if (typeof window !== "undefined") {
    return localStorage.getItem("language");
  }
  return null;
};

const Axios = axios.create({
  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
  headers: {
    Authorization: `Bearer ${getToken()}`,
    "Content-Type": "application/json;charset=UTF-8",
    "Accept-Language": `${getLanguage()}`,
  },
});
```

<br/>

## 📁 구현 결과 (선택)

![image](https://github.com/user-attachments/assets/8b878c5f-71a0-47cb-9637-296aa0b7e676)

![image](https://github.com/user-attachments/assets/1065fc13-9e97-456b-ab16-ebcc40d3aefd)

![image](https://github.com/user-attachments/assets/f542ff50-38fc-45f5-92ba-b5d4a423b421)

![image](https://github.com/user-attachments/assets/5e9700c2-a4d4-4d4a-afe1-a69aac1f2a8e)

<br/>

## 📁 기타 사항

리뷰어가 특별히 봐주었으면 하는 부분이나 주의사항, 알림사항 등이 있다면 작성해주세요.
<br/> ex) 더미 데이터를 넣어서 기능 구현한 상태입니다!

<br/>
