### PR TITLE
[Feat] 홈, 소식 번역 기능

### DIFF
--- a/src/components/common/ListBox.tsx
+++ b/src/components/common/ListBox.tsx
@@ -273,7 +273,12 @@ const Time = styled.div`
   ${(props) => props.theme.fonts.caption2_m};
   border-radius: 0px 8px 8px 0px;
   background: rgba(255, 135, 0, 0.15);
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  -webkit-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
   &.mint {
     color: ${theme.colors.sub_mint};
     background: rgba(5, 206, 194, 0.15);

--- a/src/components/common/Popup.tsx
+++ b/src/components/common/Popup.tsx
@@ -98,11 +98,13 @@ const Title = styled.div`
   position: sticky;
   top: 0;
   background: ${theme.colors.white};
-  z-index: 1;
+  z-index: 100;
 `;
 
 const TitleBox = styled.div`
   width: 100%;
+  background: ${theme.colors.white};
+  z-index: 100;
 `;
 
 const ImageBox = styled.div`

--- a/src/components/home/AddTodoPopup.tsx
+++ b/src/components/home/AddTodoPopup.tsx
@@ -8,9 +8,11 @@ import Calendar from "../common/Calendar";
 import Axios from "@/apis/axios";
 import {
   addTodoMessage,
+  calendarPlaceHolder,
   categories,
   LanguageKeys,
   submitMessage,
+  todoPlaceHolder,
   whenTodoMessage,
 } from "@/data/todoData";
 
@@ -81,7 +83,7 @@ const AddTodoPopup = ({
       >
         <CustomInput
           value={todo}
-          placeholder="할 일을 입력해주세요"
+          placeholder={`${todoPlaceHolder[language as keyof typeof todoPlaceHolder]}`}
           onChange={(value: string) => setTodo(value)}
         />
         <RadioButtonGroup>
@@ -97,7 +99,11 @@ const AddTodoPopup = ({
         </RadioButtonGroup>
         <SubTitle>
           {whenTodoMessage[language as keyof typeof whenTodoMessage]}
-          <Calendar value={selectedDate} onChange={handleDateChange} />
+          <Calendar
+            value={selectedDate}
+            onChange={handleDateChange}
+            placeholder={`${calendarPlaceHolder[language as keyof typeof calendarPlaceHolder]}`}
+          />
         </SubTitle>
         <Button
           text={`${submitMessage[language as keyof typeof submitMessage]}`}
@@ -124,6 +130,7 @@ const RadioButtonGroup = styled.div`
   display: flex;
   margin: 12px 0px 24px 0px;
   gap: 8px;
+  overflow-x: scroll;
 `;
 
 const RadioButton = styled.label<{ selected: boolean }>`
@@ -139,5 +146,6 @@ const RadioButton = styled.label<{ selected: boolean }>`
   color: ${(props) =>
     props.selected ? theme.colors.primary500 : theme.colors.b500};
   cursor: pointer;
+  white-space: nowrap;
   ${(props) => props.theme.fonts.body3_m};
 `;

--- a/src/components/home/AddTodoPopup.tsx
+++ b/src/components/home/AddTodoPopup.tsx
@@ -1,19 +1,18 @@
 import { theme } from "@/styles/theme";
 import styled from "styled-components";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Button from "../common/Button";
 import CustomInput from "../common/CustomInput";
 import Popup from "../common/Popup";
 import Calendar from "../common/Calendar";
 import Axios from "@/apis/axios";
-
-export const categories = [
-  { value: "SCHOOL_ANNOUNCEMENT", label: "가정통신문" },
-  { value: "HOMEWORK", label: "숙제" },
-  { value: "SUPPLY", label: "준비물" },
-  { value: "ETC", label: "기타" },
-  { value: "NONE", label: "없음" },
-];
+import {
+  addTodoMessage,
+  categories,
+  LanguageKeys,
+  submitMessage,
+  whenTodoMessage,
+} from "@/data/todoData";
 
 interface AddTodoPopupProps {
   onClose: () => void;
@@ -32,6 +31,11 @@ const AddTodoPopup = ({
   const [category, setCategory] = useState("");
   const [selectedDate, setSelectedDate] = useState("");
   const isButtonEnabled = todo !== "" && category !== "" && selectedDate !== "";
+  const [language, setLanguage] = useState<string>("ko");
+
+  useEffect(() => {
+    setLanguage(localStorage.getItem("language") || "ko");
+  }, []);
 
   const handleCategoryChange = (value: string) => {
     setCategory(value);
@@ -70,7 +74,11 @@ const AddTodoPopup = ({
 
   return (
     <>
-      <Popup onClose={onClose} title="할 일 직접 추가하기" height="435px">
+      <Popup
+        onClose={onClose}
+        title={`${addTodoMessage[language as keyof typeof addTodoMessage]}`}
+        height="435px"
+      >
         <CustomInput
           value={todo}
           placeholder="할 일을 입력해주세요"
@@ -83,16 +91,16 @@ const AddTodoPopup = ({
               selected={category === categoryItem.value}
               onClick={() => handleCategoryChange(categoryItem.value)}
             >
-              {categoryItem.label}
+              {categoryItem.label[language as LanguageKeys]}
             </RadioButton>
           ))}
         </RadioButtonGroup>
         <SubTitle>
-          언제까지 할 일인가요?
+          {whenTodoMessage[language as keyof typeof whenTodoMessage]}
           <Calendar value={selectedDate} onChange={handleDateChange} />
         </SubTitle>
         <Button
-          text="등록하기"
+          text={`${submitMessage[language as keyof typeof submitMessage]}`}
           onClick={handleButtonClick}
           disabled={!isButtonEnabled}
         />

--- a/src/components/home/MealTable.tsx
+++ b/src/components/home/MealTable.tsx
@@ -5,6 +5,7 @@ import MealTablePopup from "./MealTablePopup";
 import More from "../common/More";
 import Axios from "@/apis/axios";
 import Image from "next/image";
+import { cautionMessage, noDataMessage } from "@/data/mealData";
 
 interface Food {
   food: string;
@@ -18,6 +19,7 @@ interface Meal {
 const MealTable = () => {
   const [mealToday, setMealToday] = useState<Meal>({ foods: [] });
   const [mealTable, setMealTable] = useState(false);
+  const [language, setLanguage] = useState<string>("ko");
 
   const handleOpenMealTable = () => {
     setMealTable(true);
@@ -26,6 +28,10 @@ const MealTable = () => {
   const handleCloseMealTable = () => {
     setMealTable(false);
   };
+
+  useEffect(() => {
+    setLanguage(localStorage.getItem("language") || "ko");
+  }, []);
 
   useEffect(() => {
     Axios.get(`/api/v1/menus/today`)
@@ -49,7 +55,7 @@ const MealTable = () => {
               {data.food}
               {data.warning && (
                 <Caution>
-                  자녀가 주의해야 할 메뉴예요
+                  {cautionMessage[language as keyof typeof cautionMessage]}
                   <Image
                     src="/assets/icons/ic_alert.svg"
                     width={16}
@@ -61,7 +67,9 @@ const MealTable = () => {
             </List>
           ))
         ) : (
-          <NoData>급식 정보가 없어요 :(</NoData>
+          <NoData>
+            {noDataMessage[language as keyof typeof noDataMessage]}
+          </NoData>
         )}
       </TableContainer>
       {mealTable && <MealTablePopup onClose={handleCloseMealTable} />}

--- a/src/components/home/MealTablePopup.tsx
+++ b/src/components/home/MealTablePopup.tsx
@@ -30,10 +30,7 @@ const MenuCard = ({
 
   return (
     <Card>
-      <DateBox>
-        {day}
-        {dayText[language as keyof typeof dayText]}
-      </DateBox>
+      <DateBox>{dayText(day, language)}</DateBox>
       <Menus>
         {foods.map((item, index) => (
           <MenuItem key={index} $warning={item.warning}>
@@ -109,16 +106,13 @@ const MealTablePopup = ({ onClose }: { onClose: () => void }) => {
   return (
     <Popup
       onClose={onClose}
-      title={`${monthText(month, language)}월 급식표`}
+      title={`${monthText(month, language)}`}
       height="716px"
     >
       <StyledTable>
         {weeklyMealTable.map((week, weekIndex) => (
           <>
-            <Title>
-              {weekText(month, weekIndex + 1, language)}
-              {/* {month}월 {weekIndex + 1}주차 */}
-            </Title>
+            <Title>{weekText(month, weekIndex + 1, language)}</Title>
             <Week key={weekIndex}>
               {week.map((data, index) => (
                 <MenuCard key={index} date={data.date} foods={data.foods} />

--- a/src/components/home/MealTablePopup.tsx
+++ b/src/components/home/MealTablePopup.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import Popup from "../common/Popup";
 import { useEffect, useState } from "react";
 import Axios from "@/apis/axios";
+import { dayText, monthText, weekText } from "@/data/mealData";
 
 interface MealTable {
   date: string;
@@ -21,9 +22,18 @@ const MenuCard = ({
     day = day[1];
   }
 
+  const [language, setLanguage] = useState<string>("ko");
+
+  useEffect(() => {
+    setLanguage(localStorage.getItem("language") || "ko");
+  }, []);
+
   return (
     <Card>
-      <DateBox>{day}일</DateBox>
+      <DateBox>
+        {day}
+        {dayText[language as keyof typeof dayText]}
+      </DateBox>
       <Menus>
         {foods.map((item, index) => (
           <MenuItem key={index} $warning={item.warning}>
@@ -41,6 +51,11 @@ const MealTablePopup = ({ onClose }: { onClose: () => void }) => {
   /* 주간별 급식 데이터 */
   const [weeklyMealTable, setWeeklyMealTable] = useState<MealTable[][]>([]);
   const [month, setMonth] = useState<string>("");
+  const [language, setLanguage] = useState<string>("ko");
+
+  useEffect(() => {
+    setLanguage(localStorage.getItem("language") || "ko");
+  }, []);
 
   useEffect(() => {
     Axios.get(`/api/v1/menus/month`)
@@ -92,12 +107,17 @@ const MealTablePopup = ({ onClose }: { onClose: () => void }) => {
   }, []);
 
   return (
-    <Popup onClose={onClose} title={`${month}월 급식표`} height="716px">
+    <Popup
+      onClose={onClose}
+      title={`${monthText(month, language)}월 급식표`}
+      height="716px"
+    >
       <StyledTable>
         {weeklyMealTable.map((week, weekIndex) => (
           <>
             <Title>
-              {month}월 {weekIndex + 1}주차
+              {weekText(month, weekIndex + 1, language)}
+              {/* {month}월 {weekIndex + 1}주차 */}
             </Title>
             <Week key={weekIndex}>
               {week.map((data, index) => (

--- a/src/components/home/Notification.tsx
+++ b/src/components/home/Notification.tsx
@@ -63,7 +63,7 @@ const NotiContainer = styled.div`
   ${(props) => props.theme.fonts.body2_b};
   color: ${theme.colors.b700};
   letter-spacing: -0.28px;
-  z-index: -10;
+  z-index: 100;
 `;
 
 const Title = styled.div`

--- a/src/components/home/TimeTable.tsx
+++ b/src/components/home/TimeTable.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import Card, { CardProps } from "../common/Card";
 import Axios from "@/apis/axios";
 import { useEffect, useState } from "react";
+import { noDataMessage } from "@/data/timeTableData";
 
 interface Timetable {
   time: number;
@@ -13,6 +14,12 @@ const TimeTable = () => {
   const [timeToday, setTimeToday] = useState<Timetable[]>([]);
   let now = new Date();
   const week = ["일", "월", "화", "수", "목", "금", "토"];
+
+  const [language, setLanguage] = useState<string>("ko");
+
+  useEffect(() => {
+    setLanguage(localStorage.getItem("language") || "ko");
+  }, []);
 
   useEffect(() => {
     Axios.get(`/api/v1/timetables/today`)
@@ -38,7 +45,9 @@ const TimeTable = () => {
             />
           ))
         ) : (
-          <NoData>시간표 정보가 없어요 :(</NoData>
+          <NoData>
+            {noDataMessage[language as keyof typeof noDataMessage]}
+          </NoData>
         )}
       </TableContainer>
     </TimeContainer>

--- a/src/components/home/Todo.tsx
+++ b/src/components/home/Todo.tsx
@@ -3,14 +3,19 @@ import { theme } from "@/styles/theme";
 import Image from "next/image";
 import ListBox from "../common/ListBox";
 import { useEffect, useRef, useState } from "react";
-import AddTodoPopup, { categories } from "./AddTodoPopup";
+import AddTodoPopup from "./AddTodoPopup";
 import Toast from "../common/Toast";
 import Axios from "@/apis/axios";
 import { setAudio } from "@/redux/slices/audioSlice";
 import { useDispatch } from "react-redux";
-import { RootState } from "@/redux/store";
-import { useSelector } from "react-redux";
 import { getSpeech } from "@/utils/getSpeech";
+import {
+  addTodoMessage,
+  categories,
+  dayOfWeekText,
+  LanguageKeys,
+  noTodoMessage,
+} from "@/data/todoData";
 
 interface Todo {
   todoId: number;
@@ -29,11 +34,16 @@ const Todo = () => {
   /* useEffect에서 의존성 배열로 넘기는, 렌더링 알림 역할 */
   const [render, setRenderData] = useState(false);
   const week = ["일", "월", "화", "수", "목", "금", "토"];
+  const [language, setLanguage] = useState<string>("ko");
 
   /* 날짜를 yyyy-mm-dd 형식으로 변환하는 함수 */
   const formatDate = (date: Date) => {
     return date.toISOString().split("T")[0];
   };
+
+  useEffect(() => {
+    setLanguage(localStorage.getItem("language") || "ko");
+  }, []);
 
   useEffect(() => {
     let formattedDate = formatDate(currentDate);
@@ -230,19 +240,21 @@ const Todo = () => {
                 type={
                   categories.find(
                     (category) => category.value === data.todoType
-                  )?.label || data.todoType
+                  )?.label[language as LanguageKeys] || data.todoType
                 }
                 onClick={() => {
                   changeTodo(data.todoId);
                 }}
                 text={data.description}
-                time={`${getDayOfWeek(data.deadline)}까지`}
+                time={`${dayOfWeekText(getDayOfWeek(data.deadline))[language as keyof typeof dayOfWeekText]}`}
                 checked={data.status === "COMPLETE"}
                 onDelete={() => deleteTodo(data.todoId)}
               />
             ))
           ) : (
-            <NoData>할 일이 없어요!</NoData>
+            <NoData>
+              {noTodoMessage[language as keyof typeof noTodoMessage]}
+            </NoData>
           )}
         </TodoLists>
         <Plus>
@@ -253,7 +265,7 @@ const Todo = () => {
               width={20}
               height={20}
             />
-            할 일 직접 추가하기
+            {addTodoMessage[language as keyof typeof addTodoMessage]}
           </PlusButton>
         </Plus>
         {addTodo && (

--- a/src/components/home/Todo.tsx
+++ b/src/components/home/Todo.tsx
@@ -16,6 +16,7 @@ import {
   LanguageKeys,
   noTodoMessage,
 } from "@/data/todoData";
+import { addTodoToast } from "@/data/toastMessagesData";
 
 interface Todo {
   todoId: number;
@@ -281,7 +282,7 @@ const Todo = () => {
         )}
         {showToast && (
           <Toast
-            message="할 일이 추가되었어요!"
+            message={`${addTodoToast[language as keyof typeof addTodoToast]}`}
             type="basic"
             duration={2000}
             onClose={() => setShowToast(false)}

--- a/src/components/home/Todo.tsx
+++ b/src/components/home/Todo.tsx
@@ -152,8 +152,9 @@ const Todo = () => {
     const text =
       date +
       `.  ${getDateString(currentDate)} ${getDateString(currentDate) === "오늘" ? "해야할" : "했어야 할"} 일은.  ` +
-      unassignedTodos +
-      "입니다.";
+      (unassignedTodos.length > 0
+        ? `${unassignedTodos.join(" ")} 입니다.`
+        : "없습니다.");
 
     getSpeech(text, () => {
       dispatch(setAudio(false));
@@ -220,14 +221,16 @@ const Todo = () => {
               }}
             />
           </DateLine>
-          <Image
-            src="/assets/icons/ic_volumn.svg"
-            alt="sound"
-            width={21}
-            height={21}
-            onClick={handleVoiceConversion}
-            style={{ cursor: "pointer" }}
-          />
+          {language === "ko" && (
+            <Image
+              src="/assets/icons/ic_volumn.svg"
+              alt="sound"
+              width={21}
+              height={21}
+              onClick={handleVoiceConversion}
+              style={{ cursor: "pointer" }}
+            />
+          )}
         </Row>
         <TodoLists>
           {todoData && todoData.length > 0 ? (

--- a/src/components/news/Summary.tsx
+++ b/src/components/news/Summary.tsx
@@ -1,6 +1,8 @@
 import { theme } from "@/styles/theme";
 import styled from "styled-components";
 import SummaryCard from "./SummaryCard";
+import { summaryTranslation } from "@/data/newsData";
+import { useEffect, useState } from "react";
 
 export type summaryType = "simple" | "detail";
 
@@ -28,10 +30,18 @@ const Summary = ({
   type: string;
   dummyData: AnnouncementsProps[];
 }) => {
+  const [language, setLanguage] = useState<string>("ko");
+
+  useEffect(() => {
+    setLanguage(localStorage.getItem("language") || "ko");
+  }, []);
+
   return (
     <Container>
       <Content>
-        <Title>가정통신문, 세 문장 요약해드려요</Title>
+        <Title>
+          {summaryTranslation[language as keyof typeof summaryTranslation]}
+        </Title>
         {dummyData.map((data, index) => (
           <SummaryCard
             type={type === "school" ? "school" : "eduOffice"}

--- a/src/components/news/SummaryCard.tsx
+++ b/src/components/news/SummaryCard.tsx
@@ -1,7 +1,9 @@
 import ListNumber from "@/components/common/ListNumber";
+import { newText } from "@/data/newsData";
 import { theme } from "@/styles/theme";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 
 interface Line {
@@ -23,19 +25,89 @@ interface AnnouncementsProps {
 }
 
 interface CategoryMap {
-  [key: string]: string;
+  [key: string]: {
+    ko: string;
+    en: string;
+    zh: string;
+    ja: string;
+    vi: string;
+    pi: string;
+  };
 }
 
 const categoryMap: CategoryMap = {
-  NONE: "미선택",
-  MENU: "급식",
-  INTERNAL_EXTERNAL_PROGRAM: "교내외 프로그램",
-  SCHOOL_MANAGEMENT: "학교 운영",
-  HEALTH: "보건",
-  SCHOOL_SCHEDULE: "학교 일정",
-  EDUCATION_BENEFIT: "교육 혜택",
-  LIFE_SAFE: "생활/안전",
-  ETC: "기타",
+  NONE: {
+    ko: "미선택",
+    en: "None",
+    zh: "到明天为止",
+    ja: "明日までに",
+    vi: "Đến-ngày Mai",
+    pi: "Hanggang-Bukas",
+  },
+  MENU: {
+    ko: "급식",
+    en: "Lunch",
+    zh: "餐",
+    ja: "給食",
+    vi: "Ăn trưa",
+    pi: "Kain",
+  },
+  INTERNAL_EXTERNAL_PROGRAM: {
+    ko: "교내외 프로그램",
+    en: "Program",
+    zh: "程序",
+    ja: "プログラム",
+    vi: "Chương trình",
+    pi: "Programa",
+  },
+  SCHOOL_MANAGEMENT: {
+    ko: "학교 운영",
+    en: "Operation",
+    zh: "运营",
+    ja: "運営",
+    vi: "Vận hành",
+    pi: "Pamamahala",
+  },
+  HEALTH: {
+    ko: "보건",
+    en: "None",
+    zh: "健康",
+    ja: "健康",
+    vi: "Sức khỏe",
+    pi: "Kalusugan",
+  },
+  SCHOOL_SCHEDULE: {
+    ko: "학교 일정",
+    en: "Schedule",
+    zh: "日程",
+    ja: "予定",
+    vi: "Lịch",
+    pi: "Iskedyul",
+  },
+  EDUCATION_BENEFIT: {
+    ko: "교육 혜택",
+    en: "Benefit",
+    zh: "优惠",
+    ja: "特典",
+    vi: "Lợi ích",
+    pi: "Benepisyo",
+  },
+  LIFE_SAFE: {
+    ko: "생활/안전",
+    en: "Safety",
+    zh: "安全",
+    ja: "安全",
+    vi: "An toàn",
+    pi: "Ligtas",
+  },
+  ETC: {
+    ko: "기타",
+    en: "ETC",
+    zh: "等",
+    ja: "等",
+    vi: "Vân vân",
+    pi: "Atbp",
+  },
 };
 
 const SummaryCard = (props: AnnouncementsProps) => {
@@ -53,6 +125,11 @@ const SummaryCard = (props: AnnouncementsProps) => {
   } = props;
 
   const router = useRouter();
+  const [language, setLanguage] = useState<string>("ko");
+
+  useEffect(() => {
+    setLanguage(localStorage.getItem("language") || "ko");
+  }, []);
 
   const handleCardClick = (type: string, announcementId: number) => {
     router.push(`/news/${type}/${announcementId}`);
@@ -69,8 +146,16 @@ const SummaryCard = (props: AnnouncementsProps) => {
     >
       <Top>
         <Label>
-          {isNew && <New>NEW</New>}
-          {category !== "NONE" && <Category>{categoryMap[category]}</Category>}
+          {isNew && <New>{newText[language as keyof typeof newText]}</New>}
+          {category !== "NONE" && (
+            <Category>
+              {
+                categoryMap[category][
+                  language as keyof (typeof categoryMap)[keyof CategoryMap]
+                ]
+              }
+            </Category>
+          )}
         </Label>
       </Top>
       <Title className={summaryType}>{title}</Title>

--- a/src/data/mealData.ts
+++ b/src/data/mealData.ts
@@ -9,7 +9,7 @@ export const cautionMessage = {
 
   export const noDataMessage = {
     ko: "급식 정보가 없어요 :(",
-    en: "I don't have any information about school meals :(",
+    en: "No information about school meals :(",
     zh: "伙食信息不存在 :(",
     ja: "給食情報がありません :(",
     vi: "Không có thông tin về bữa ăn :(",
@@ -54,11 +54,21 @@ export const cautionMessage = {
     }
   };
 
-  export const dayText = {
-    ko: "일",
-    en: "Day",
-    zh: "日",
-    ja: "日",
-    vi: "Ngày",
-    pi: "Araw",
+  export const dayText = (day:string, language:string) => {
+    switch(language) {
+        case "ko":
+            return `${day}일`;
+        case "en":
+            return `Day ${day}`;
+        case "zh":
+            return `${day}日`;
+        case "ja":
+            return `${day}日`;
+        case "vi":
+            return `Ngày ${day}`;
+        case "pi":
+            return `${day} araw`;
+        default:
+            return null;
+    }
   };

--- a/src/data/mealData.ts
+++ b/src/data/mealData.ts
@@ -1,0 +1,64 @@
+export const cautionMessage = {
+    ko: "주의!",
+    en: "Caution!",
+    zh: "注意!",
+    ja: "注意!",
+    vi: "Chú ý!",
+    pi: "Ingat!",
+  };
+
+  export const noDataMessage = {
+    ko: "급식 정보가 없어요 :(",
+    en: "I don't have any information about school meals :(",
+    zh: "伙食信息不存在 :(",
+    ja: "給食情報がありません :(",
+    vi: "Không có thông tin về bữa ăn :(",
+    pi: "Walang impormasyon sa pagkain :(",
+  };
+
+  export const monthText = (month:string, language:string) => {
+    switch(language) {
+        case "ko":
+            return `${month}월 급식표`;
+        case "en":
+            return `September`;
+        case "zh":
+            return `${month}月`;
+        case "ja":
+            return `${month}月`;
+        case "vi":
+            return `Tháng ${month}`;
+        case "pi":
+            return `Setyembre`;
+        default:
+            return null;
+    }
+  };
+
+  export const weekText = (month: string, week:number, language:string) => {
+    switch(language) {
+        case "ko":
+            return `${month}월 ${week}주차`;
+        case "en":
+            return `Week ${week} of Sep`;
+        case "zh":
+            return `${month}月第${week}周`;
+        case "ja":
+            return `${month}月第${week}週`;
+        case "vi":
+            return `Tuần ${week} tháng ${month}`;
+        case "pi":
+            return `Linggo ${week} Set`;
+        default:
+            return null;
+    }
+  };
+
+  export const dayText = {
+    ko: "일",
+    en: "Day",
+    zh: "日",
+    ja: "日",
+    vi: "Ngày",
+    pi: "Araw",
+  };

--- a/src/data/newsData.ts
+++ b/src/data/newsData.ts
@@ -1,0 +1,17 @@
+export const newText = {
+    ko: "NEW",
+    en: "NEW",
+    zh: "新しい",
+    ja: "注意!",
+    vi: "Mới",
+    pi: "Bago",
+  };
+
+export const summaryTranslation = {
+    ko: "가정통신문, 세 문장 요약해드려요",
+    en: "Home notice, summarized in three sentences", 
+    zh: "家庭通知书，三句话总结", 
+    ja: "家庭通信を3つの文で要約します", 
+    vi: "Thông báo gia đình, tóm tắt trong ba câu",
+    pi: "Pabatid sa Pamilya, tatlong pangungusap na buod",
+  };

--- a/src/data/timeTableData.ts
+++ b/src/data/timeTableData.ts
@@ -1,0 +1,8 @@
+export const noDataMessage = {
+    ko: "시간표 정보가 없어요:(",
+    en: "No schedule information available :(",
+    zh: "没有时间表信息:(",
+    ja: "時間割情報がありません:(",
+    vi: "Không có thông tin thời khóa biểu :(",
+    pi: "Walang impormasyon sa iskedyul :(",
+  };

--- a/src/data/toastMessagesData.ts
+++ b/src/data/toastMessagesData.ts
@@ -6,3 +6,12 @@ export const ToastMessages = {
   vi: "Đã nộp",
   pi: "Nai-submit na",
 };
+
+export const addTodoToast = {
+  ko: "할 일이 추가되었어요!",
+  en: "A task has been added!",
+  zh: "任务已添加！",
+  ja: "タスクが追加されました！", 
+  vi: "Một công việc đã được thêm vào!",
+  pi: "Mayroong bagong gawain na idinagdag!",
+};

--- a/src/data/todoData.ts
+++ b/src/data/todoData.ts
@@ -139,6 +139,15 @@ export const dayOfWeekText = (day: string) => {
     pi: "Direktang Magdagdag ng Gawain",
   };
   
+  export const todoPlaceHolder = {
+    ko: "할 일을 입력해주세요",
+    en: "Please enter a task",
+    zh: "请输入任务",
+    ja: "タスクを入力してください",
+    vi: "Vui lòng nhập công việc",
+    pi: "Pakilagay ang gawain",
+  };
+  
   export const whenTodoMessage = {
     ko: "언제까지 할 일인가요?",
     en: "Until when will you be doing it?",
@@ -148,6 +157,15 @@ export const dayOfWeekText = (day: string) => {
     pi: "Hanggang kailan ito gagawin?",
   };
   
+  export const calendarPlaceHolder = {
+    ko: "날짜를 선택해주세요",
+    en: "Please select a date",
+    zh: "请选择日期",
+    ja: "日付を選択してください",
+    vi: "Vui lòng chọn ngày",
+    pi: "Pakipili ang petsa",   
+  };
+
   export const submitMessage = {
     ko: "등록하기",
     en: "To add",

--- a/src/data/todoData.ts
+++ b/src/data/todoData.ts
@@ -1,0 +1,158 @@
+export type LanguageKeys = 'ko' | 'en' | 'zh' | 'ja' | 'vi' | 'pi';
+
+export const categories = [
+    { value: "SCHOOL_ANNOUNCEMENT", label: {
+        ko: "가정통신문",
+        en: "Home Notice",
+        zh: "家庭通知书",
+        ja: "家庭通信",
+        vi: "Thông báo gia đình",
+        pi: "Pabatid sa Pamilya",
+    }},
+    { value: "HOMEWORK", label: {
+        ko: "숙제",
+        en: "Homework",
+        zh: "作業",
+        ja: "宿題",
+        vi: "Bài tập về nhà",
+        pi: "Hanggang-Bukas",
+    }},
+    { value: "SUPPLY", label: {
+        ko: "준비물",
+        en: "Materials",
+        zh: "准备物品",
+        ja: "準備物",
+        vi: "Vật dụng chuẩn bị",
+        pi: "Takdang-aralin",
+    }},
+    { value: "ETC", label: {
+        ko: "기타",
+        en: "ETC",
+        zh: "等",
+        ja: "等",
+        vi: "Vân vân",
+        pi: "Atbp",
+    }},
+    { value: "NONE", label: {
+        ko: "없음",
+        en: "None",
+        zh: "到明天为止",
+        ja: "明日までに",
+        vi: "Đến-ngày Mai",
+        pi: "Hanggang-Bukas",
+    }},
+  ];
+
+export const dayOfWeekText = (day: string) => {
+    switch (day) {
+        case "내일":
+            return {
+                ko: "내일까지",
+                en: "By Tomorrow",
+                zh: "到明天为止",
+                ja: "明日までに",
+                vi: "Đến-ngày Mai",
+                pi: "Hanggang-Bukas",
+            };
+        case "화요일":
+            return {
+                ko: "화요일까지",
+                en: "By Tuesday",
+                zh: "到星期二为止",
+                ja: "火曜日まで",
+                vi: "Đến-thứ Ba",
+                pi: "Hanggang-Martes",
+            };
+        case "수요일":
+            return {
+                ko: "수요일까지",
+                en: "By Wednesday",
+                zh: "到星期三为止",
+                ja: "水曜日まで",
+                vi: "Đến-thứ Tư",
+                pi: "Hanggang-Miyerkules",
+            };
+        case "목요일":
+            return {
+                ko: "목요일까지",
+                en: "By Thursday",
+                zh: "到星期四为止",
+                ja: "木曜日まで!",
+                vi: "Đến-thứ Năm",
+                pi: "Hanggang-Huwebes",
+            };
+        case "금요일":
+            return {
+                ko: "금요일까지",
+                en: "By Friday",
+                zh: "到星期五为止",
+                ja: "金曜日まで",
+                vi: "Đến-thứ Sáu",
+                pi: "Hanggang-Biyernes",
+            };
+        case "토요일":
+            return {
+                ko: "토요일까지",
+                en: "By Saturday",
+                zh: "到星期六为止",
+                ja: "土曜日まで",
+                vi: "Đến-thứ Bảy",
+                pi: "Hanggang-Sabado",
+            };
+        case "일요일":
+            return {
+                ko: "일요일까지",
+                en: "By Sunday",
+                zh: "到星期天为止",
+                ja: "日曜日まで",
+                vi: "Đến-chủ Nhật",
+                pi: "Hanggang-Linggo",
+            };
+        default:
+            return {
+                ko: "월요일까지",
+                en: "By Monday",
+                zh: "到星期一为止",
+                ja: "月曜日まで",
+                vi: "Đến-thứ Hai",
+                pi: "Hanggang-Lunes",
+            };
+            
+    }
+  };
+
+  export const noTodoMessage = {
+    ko: "할 일이 없어요!",
+    en: "There's nothing to do!",
+    zh: "沒事可做！",
+    ja: "やることがありません！",
+    vi: "Không có việc gì để làm!",
+    pi: "Walang magawa!",
+  };
+
+  export const addTodoMessage = {
+    ko: "할 일 직접 추가하기",
+    en: "Directly Add Tasks",
+    zh: "直接添加任务",
+    ja: "タスクを直接追加する",
+    vi: "Thêm công việc trực tiếp",
+    pi: "Direktang Magdagdag ng Gawain",
+  };
+  
+  export const whenTodoMessage = {
+    ko: "언제까지 할 일인가요?",
+    en: "Until when will you be doing it?",
+    zh: "要做到什麼時候?",
+    ja: "いつまでやることですか?",
+    vi: "Việc này sẽ làm đến khi nào?",
+    pi: "Hanggang kailan ito gagawin?",
+  };
+  
+  export const submitMessage = {
+    ko: "등록하기",
+    en: "To add",
+    zh: "添加",
+    ja: "追加する",
+    vi: "Thêm vào",
+    pi: "Idagdag",
+  };


### PR DESCRIPTION
## 연관 이슈

close #138

<br/>

## 📁 작업 내용

- 홈, 소식 API 호출 language 적용
- 홈, 소식 프론트 데이터 언어별 문서화 및 변환
- 반응형 css 

<br/>

## 📁 구현 결과 (선택)

https://github.com/user-attachments/assets/d7a1d642-963c-4e41-ba18-651b1a9e4e24



<br/>

## 📁 기타 사항
- hyphens 속성이 Chrome에서는 호환이 안된다고 하더라구요!
그래서 배포하고 Safari에서 확인해보려 합니다.
![image](https://github.com/user-attachments/assets/225a2091-1f3e-4f7d-9f66-8573d719cb38)
- 번역은 백엔드에서 넘어와야 하는 부분 제외하고 다 작업했습니다~
추가적으로 연동 후에 마무리로 컴포넌트 크기 다듬는 작업만 하면 될 것 같아요:)

merge는 그냥 제가 바로 할게용

<br/>
