### PR TITLE
[Fix] 지난 알림장에서 오늘 알림장 내용 제거

### DIFF
--- a/src/components/school/notification/LastNotifications.tsx
+++ b/src/components/school/notification/LastNotifications.tsx
@@ -24,7 +24,7 @@ const LastNotifications = () => {
       .then((response) => {
         const { teacherName, announcements } = response.data;
         setTeacher(teacherName);
-        setLastNotiData(announcements);
+        setLastNotiData(announcements.slice(1));
       })
       .catch(() => {
         console.error("All Noti Get Error");


### PR DESCRIPTION
## 연관 이슈

close #140

<br/>

## 📁 작업 내용

지난 알림장에 오늘의 알림장 내용 안보이도록 수정
<br/>

## 📁 구현 결과 (선택)
![image](https://github.com/user-attachments/assets/66ca465a-073d-4bda-8f0e-5e937cf9f933)
![image](https://github.com/user-attachments/assets/a0f788a0-a36d-4825-b949-f51d8b128b46)

<br/>
